### PR TITLE
chore: whitelist orion-usd, orion-luna pair

### DIFF
--- a/src/assets/whiteList.ts
+++ b/src/assets/whiteList.ts
@@ -47,6 +47,8 @@ export const whiteList = {
     terra1wrwf3um5vm30vpwnlpvjzgwpf5fjknt68nah05: 'LUNAHODL',
     terra1etdkg9p0fkl8zal6ecp98kypd32q8k3ryced9d: 'TWD-UST',
     terra1e59utusv5rspqsu8t37h5w887d9rdykljedxw0: 'VKR-UST',
+    terra1z6tp0ruxvynsx5r9mmcc2wcezz9ey9pmrw5r8g: 'ORION-UST',
+    terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725: 'ORION-LUNA'
   },
   token: {
     uusd: 'UST',
@@ -97,5 +99,6 @@ export const whiteList = {
     terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2: "bLUNA-LUNA LP",
     terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6: 'TWD',
     terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5: 'VKR',
+    terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03: 'ORION'
   }
 }


### PR DESCRIPTION
### Background
- ORION pairs are missing on the whitelist

### Problem 
- Cannot query due to the whitelisted pair limit on the source code

### Solution
- Add missing pairs 

[ORION](https://github.com/terra-money/assets/blob/8c5cf43adad0d35669097889ff1b5d716dcfa7c6/cw20/tokens.json#L313) 
[UST-ORION Pair](https://github.com/terra-money/assets/blob/8c5cf43adad0d35669097889ff1b5d716dcfa7c6/cw20/pairs.json#L42
)
[LUNA-ORION Pair](https://finder.terra.money/columbus-5/address/terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725)



